### PR TITLE
Add dirty grid slot mechanic (cleaning & Burnt Scrap handling)

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -417,19 +417,26 @@ function renderGrid() {
       cell.classList.remove("portal");
       cell.classList.remove("cryo");
       cell.classList.remove("ash-cleaner");
+      cell.classList.toggle("dirty", !!tile.dirty);
       cell.style.setProperty("--tile-accent", "transparent");
-      if (label) label.textContent = "Empty";
+      if (label) label.textContent = tile.dirty ? "Dirty" : "Empty";
       if (heat) heat.textContent = "";
       if (progress) progress.style.display = "none";
       if (bar) bar.style.width = "0%";
       if (transfer) transfer.style.opacity = 0;
-      cell.title = "Empty tile. Click to build.";
+      if (tile.dirty) {
+        const burntAmount = tile.dirtyBurntScrap || 0;
+        cell.title = `Dirty tile. Clean for 500 Scrap before building.\nContains ${burntAmount} Burnt Scrap.`;
+      } else {
+        cell.title = "Empty tile. Click to build.";
+      }
       return;
     }
     const def = BUILDINGS[tile.building];
     const autoDisabled = !!tile.automationDisabled;
     const disabled = isTilePaused(tile);
     cell.classList.toggle("disabled", disabled);
+    cell.classList.remove("dirty");
     cell.classList.toggle("miner", tile.building === "Miner");
     cell.classList.toggle("smelter", tile.building === "Smelter");
     cell.classList.toggle("assembler", tile.building === "Assembler");
@@ -1361,4 +1368,3 @@ function showPrestigeOverlay() {
   });
   prestigeOverlay.classList.add("active");
 }
-

--- a/js/state.js
+++ b/js/state.js
@@ -20,6 +20,8 @@ function createTile() {
     smelterLevel: 1,
     smelterCycleCount: 0,
     ashLevel: 1,
+    dirty: false,
+    dirtyBurntScrap: 0,
     automationDisabled: false,
     automationRules: []
   };
@@ -302,6 +304,8 @@ function rehydrateState(loaded) {
     smelterLevel: Math.max(1, tile.smelterLevel || 1),
     smelterCycleCount: tile.smelterCycleCount || 0,
     ashLevel: Math.max(1, tile.ashLevel || 1),
+    dirty: !!tile.dirty,
+    dirtyBurntScrap: Math.max(0, Number(tile.dirtyBurntScrap) || 0),
     automationDisabled: false,
     automationRules: normalizeAutomationRules(tile.automationRules || [])
   }));
@@ -398,6 +402,8 @@ function createSavePayload() {
       smelterLevel: tile.smelterLevel || 1,
       smelterCycleCount: tile.smelterCycleCount || 0,
       ashLevel: tile.ashLevel || 1,
+      dirty: tile.dirty || false,
+      dirtyBurntScrap: tile.dirtyBurntScrap || 0,
       automationRules: tile.automationRules || []
     })),
     selectedBuilding: state.selectedBuilding,

--- a/styles.css
+++ b/styles.css
@@ -385,6 +385,10 @@ header {
   transition: border-color 0.15s ease, transform 0.1s ease, background 0.2s ease;
   background: linear-gradient(135deg, rgba(15,23,42,0.9), color-mix(in srgb, var(--tile-accent) 25%, rgba(15,23,42,0.9)));
 }
+.tile.dirty {
+  border-color: rgba(239, 68, 68, 0.6);
+  background: linear-gradient(135deg, rgba(127, 29, 29, 0.4), rgba(15, 23, 42, 0.9));
+}
 .tile.miner {
   background-image:
     linear-gradient(135deg, rgba(2,6,23,0.55), color-mix(in srgb, var(--tile-accent) 20%, rgba(2,6,23,0.55))),


### PR DESCRIPTION
### Motivation
- Introduce a mechanic where newly purchased grid slots can be "dirty" and must be cleaned for a Scrap cost before building, and the dirty slot contains Burnt Scrap that is moved into storage upon cleaning.
- Dirt chance should depend on free storage and how much Burnt Scrap is already stored, matching the requested formula behavior (base 0.01 plus free-space * burnt-percent factor).

### Description
- Added tile state fields `dirty` and `dirtyBurntScrap` and persisted them in `createTile`, `rehydrateState`, and the save payload in `js/state.js`.
- Added constants `GRID_DIRT_CLEAN_COST` and `GRID_DIRT_BURNT_AMOUNT`, implemented `getGridDirtChance()` and `maybeDirtyGridTile()` and hooked dirt behavior into `buyGridSlot()` and tile creation in `js/systems.js`, plus cleaning logic in `handleTileClick()` that charges `500 Scrap`, clears the dirty flag and moves the burnt scrap into storage via `addBurntScrap()`.
- Updated rendering in `js/render.js` to visually mark empty-but-dirty tiles, change the label to "Dirty", and show a tooltip with the contained Burnt Scrap and cleaning hint, and removed the dirty marker when a building occupies the tile.
- Added a `.tile.dirty` style to `styles.css` to highlight clogged slots and added log messages when slots are dirtied or cleaned.

### Testing
- Launched a local server with `python -m http.server 8000` to load the app, which started successfully. (succeeded)
- Ran a Playwright script that programmatically set a tile dirty and captured a screenshot, producing the artifact `artifacts/dirty-grid.png`. (succeeded)
- No automated unit tests were present or run for this change; changes were exercised in the browser smoke run above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978db5858f8832981c277b6b31b6380)